### PR TITLE
Detect missing license metadata

### DIFF
--- a/src/checks/packageJson.ts
+++ b/src/checks/packageJson.ts
@@ -6,6 +6,7 @@ import type { RepoCheck } from "./types.js";
 interface PackageJson {
   name?: unknown;
   version?: unknown;
+  license?: unknown;
   scripts?: unknown;
 }
 
@@ -32,7 +33,8 @@ export const checkPackageJson: RepoCheck = async ({ root }) => {
 
   const missing = [
     typeof packageJson.name === "string" && packageJson.name.length > 0 ? undefined : "name",
-    typeof packageJson.version === "string" && packageJson.version.length > 0 ? undefined : "version"
+    typeof packageJson.version === "string" && packageJson.version.length > 0 ? undefined : "version",
+    typeof packageJson.license === "string" && packageJson.license.length > 0 ? undefined : "license"
   ].filter((value): value is string => Boolean(value));
 
   if (missing.length > 0) {

--- a/test/repoDoctor.test.ts
+++ b/test/repoDoctor.test.ts
@@ -24,6 +24,7 @@ test("reports a healthy repository as passing", async () => {
     "package.json": JSON.stringify({
       name: "example",
       version: "1.0.0",
+      license: "MIT",
       scripts: { test: "node --test", lint: "tsc --noEmit" }
     })
   });
@@ -35,6 +36,24 @@ test("reports a healthy repository as passing", async () => {
     result.checks.map((check) => check.status),
     ["pass", "pass", "pass", "pass"]
   );
+});
+
+test("reports missing package license metadata", async () => {
+  const root = await makeRepo({
+    "README.md": "# Example\n",
+    "package.json": JSON.stringify({
+      name: "example",
+      version: "1.0.0",
+      scripts: { test: "node --test", lint: "tsc --noEmit" }
+    })
+  });
+
+  const result = await runDoctor({ root });
+  const packageCheck = result.checks.find((check) => check.id === "package-json");
+
+  assert.equal(result.ok, false);
+  assert.equal(packageCheck?.status, "fail");
+  assert.match(packageCheck?.message ?? "", /license/);
 });
 
 test("reports missing README, incomplete package metadata, and missing scripts", async () => {
@@ -62,6 +81,7 @@ test("reports broken relative markdown links", async () => {
     "package.json": JSON.stringify({
       name: "example",
       version: "1.0.0",
+      license: "MIT",
       scripts: { test: "node --test", lint: "tsc --noEmit" }
     })
   });


### PR DESCRIPTION
## Summary
- Require `package.json.license` as part of the package metadata check.
- Add coverage for repositories missing license metadata.
- Update passing fixtures to include a valid non-empty license string.

## Verification
- `npm run check`

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Package.json validation now requires a `license` field in addition to existing `name` and `version` checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->